### PR TITLE
rv-meta submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = https://github.com/michaeljclark/asmjit.git
 [submodule "meta"]
 	path = meta
-	url = git@github-msyksphinz:msyksphinz-self/riscv-meta.git
+	url = https://github.com/shioya-lab/riscv-meta.git
 	branch = sift


### PR DESCRIPTION
There seems to be a mistake in the URL for rv-meta in `.gitmodules`; there is a rv-meta repository in the shioya-lab organisation, so I assume this is the URL that is meant to be here.